### PR TITLE
deps(maven)(deps): bump backend minor-and-patch group with compat fixes

### DIFF
--- a/veloforge-back/pom.xml
+++ b/veloforge-back/pom.xml
@@ -9,15 +9,15 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <compiler-plugin.version>3.14.1</compiler-plugin.version>
+        <compiler-plugin.version>3.15.0</compiler-plugin.version>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.30.3</quarkus.platform.version>
+        <quarkus.platform.version>3.36.3</quarkus.platform.version>
         <skipITs>true</skipITs>
-        <surefire-plugin.version>3.5.4</surefire-plugin.version>
+        <surefire-plugin.version>3.5.6</surefire-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -139,7 +139,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>mongodb</artifactId>
+            <artifactId>testcontainers-mongodb</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -204,7 +204,7 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.7.0</version>
                 <configuration>
                     <java>
                         <googleJavaFormat>
@@ -233,7 +233,7 @@
             <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
-                <version>7.17.0</version>
+                <version>7.23.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -256,6 +256,7 @@
                                 <generateModelDocumentation>false</generateModelDocumentation>
                                 <hideGenerationTimestamp>true</hideGenerationTimestamp>
                                 <useSwaggerAnnotations>false</useSwaggerAnnotations>
+                                <openApiNullable>false</openApiNullable>
                             </configOptions>
                             <apiPackage>com.veloforge.api</apiPackage>
                             <modelPackage>com.veloforge.model</modelPackage>


### PR DESCRIPTION
Applies the backend Maven minor-and-patch group bumps from dependabot #127, plus the two compatibility fixes that PR was missing (which is why its CI failed).

## Version bumps
| Artifact | From | To |
|----------|------|-----|
| quarkus.platform | 3.30.3 | 3.36.3 |
| maven-compiler-plugin | 3.14.1 | 3.15.0 |
| maven-surefire-plugin | 3.5.4 | 3.5.6 |
| spotless-maven-plugin | 3.1.0 | 3.7.0 |
| openapi-generator-maven-plugin | 7.17.0 | 7.23.0 |

## Why #127 failed CI — two compatibility fixes

**1. Testcontainers module rename (Quarkus 3.36 → Testcontainers 2.0.5)**
```
'dependencies.dependency.version' for org.testcontainers:mongodb:jar is missing.
```
Quarkus 3.36 ships Testcontainers 2.0.5, which renamed modules from `org.testcontainers:mongodb` to `org.testcontainers:testcontainers-mongodb`. The new artifact **is** managed by `quarkus-bom`, so just renaming it (no explicit version) fixes resolution.

**2. openapi-generator `openApiNullable` default flipped to `true`**
7.23.0 generates `org.openapitools.jackson.nullable.JsonNullable` imports by default, which need the `jackson-databind-nullable` library (not a dependency here). Set `openApiNullable=false` to keep the prior generated model API without adding a new runtime dep.

## Verification
`./mvnw clean package` passes locally — **all 8 tests green**, with MongoDB / Redis / Kafka Dev Services started via Testcontainers 2.0.5.

Once merged, dependabot PR #127 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)