### PR TITLE
chore: configure Dependabot dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
 updates:
-  # Maven dependencies (Backend)
   - package-ecosystem: "maven"
     directory: "/veloforge-back"
     schedule:
@@ -9,8 +8,6 @@ updates:
       time: "09:00"
       timezone: "Europe/Paris"
     open-pull-requests-limit: 5
-    reviewers:
-      - "glandais"
     assignees:
       - "glandais"
     commit-message:
@@ -18,16 +15,12 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
-      - "backend"
-      - "maven"
     groups:
-      # Group all minor and patch updates together
       minor-and-patch:
         update-types:
           - "minor"
           - "patch"
 
-  # npm dependencies (Frontend)
   - package-ecosystem: "npm"
     directory: "/veloforge-front"
     schedule:
@@ -36,8 +29,6 @@ updates:
       time: "09:30"
       timezone: "Europe/Paris"
     open-pull-requests-limit: 10
-    reviewers:
-      - "glandais"
     assignees:
       - "glandais"
     commit-message:
@@ -45,16 +36,12 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
-      - "frontend"
-      - "npm"
     groups:
-      # Group all minor and patch updates together
       minor-and-patch:
         update-types:
           - "minor"
           - "patch"
 
-  # npm dependencies (root)
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -63,8 +50,6 @@ updates:
       time: "09:30"
       timezone: "Europe/Paris"
     open-pull-requests-limit: 10
-    reviewers:
-      - "glandais"
     assignees:
       - "glandais"
     commit-message:
@@ -72,42 +57,33 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
-      - "npm"
     groups:
-      # Group all minor and patch updates together
       minor-and-patch:
         update-types:
           - "minor"
           - "patch"
 
-  # Docker dependencies (Frontend)
   - package-ecosystem: "docker"
     directory: "/veloforge-front"
     schedule:
       interval: "weekly"
       day: "tuesday"
-      time: "09:30"
+      time: "10:00"
       timezone: "Europe/Paris"
     open-pull-requests-limit: 3
-    reviewers:
-      - "glandais"
     assignees:
       - "glandais"
     commit-message:
-      prefix: "deps(docker-frontend)"
+      prefix: "deps(docker)"
       include: "scope"
     labels:
       - "dependencies"
-      - "docker"
-      - "frontend"
     groups:
-      # Group all minor and patch updates together
       minor-and-patch:
         update-types:
           - "minor"
           - "patch"
 
-  # Docker Compose dependencies
   - package-ecosystem: "docker-compose"
     directory: "/"
     schedule:
@@ -116,8 +92,6 @@ updates:
       time: "10:00"
       timezone: "Europe/Paris"
     open-pull-requests-limit: 3
-    reviewers:
-      - "glandais"
     assignees:
       - "glandais"
     commit-message:
@@ -125,37 +99,28 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
-      - "docker-compose"
-      - "infrastructure"
     groups:
-      # Group all minor and patch updates together
       minor-and-patch:
         update-types:
           - "minor"
           - "patch"
 
-  # GitHub Actions dependencies
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "wednesday"
-      time: "09:00"
+      day: "monday"
+      time: "10:00"
       timezone: "Europe/Paris"
     open-pull-requests-limit: 5
-    reviewers:
-      - "glandais"
     assignees:
       - "glandais"
     commit-message:
-      prefix: "deps(actions)"
+      prefix: "deps(github-actions)"
       include: "scope"
     labels:
       - "dependencies"
-      - "github-actions"
-      - "ci-cd"
     groups:
-      # Group all minor and patch updates together
       minor-and-patch:
         update-types:
           - "minor"


### PR DESCRIPTION
## Summary

Standardizes the Dependabot configuration to align with the tribly reference standard. The following ecosystems are covered:

- **maven** (`/veloforge-back`): weekly on monday at 09:00
- **npm** (`/veloforge-front`): weekly on monday at 09:30
- **npm** (`/`): weekly on monday at 09:30
- **docker** (`/veloforge-front`): weekly on tuesday at 10:00
- **docker-compose** (`/`): weekly on tuesday at 10:00
- **github-actions** (`/`): weekly on monday at 10:00

Changes from previous config:
- Removed `reviewers:` key (not in standard)
- Removed extra ecosystem-specific labels (only `dependencies` is kept)
- Fixed docker time from `09:30` to `10:00`
- Fixed github-actions day from `wednesday` to `monday`, time from `09:00` to `10:00`
- Fixed commit-message prefix for docker (`deps(docker)`) and github-actions (`deps(github-actions)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)